### PR TITLE
migrate to .net2.0

### DIFF
--- a/XamarinTPLinkSmartDevices/TPLinkSmartDevices.csproj
+++ b/XamarinTPLinkSmartDevices/TPLinkSmartDevices.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>tplink-smartdevices</AssemblyName>
-    <Authors>Jakob Wilhelm</Authors>
+    <Authors>CodeBardian</Authors>
     <Company />
-    <Description>.NET Standard 1.6 Library for Discovering and Operating TP-Link Smart Devices (HS, LB and KL-series)</Description>
+    <Description>.NET Standard 2.0 Library for Discovering and Operating TP-Link Smart Devices (HS, LB and KL-series)</Description>
     <PackageProjectUrl>https://github.com/CodeBardian/tplink-smartdevices-netstandard</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CodeBardian/tplink-smartdevices-netstandard</RepositoryUrl>
     <PackageTags>TP-Link, Smart Home</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>GitHub</RepositoryType>
     <RootNamespace>TPLinkSmartDevices</RootNamespace>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
this should get rid of like almost 50 unused dependencies which are triggered on nuget install while using .net1.6