### PR TITLE
usage of different broadcast address 

### DIFF
--- a/docs/docs/docs/discovery.md
+++ b/docs/docs/docs/discovery.md
@@ -12,17 +12,22 @@ public List<TPLinkSmartDevice> DiscoveredDevices { get; private set; }
 
 ## Methods
 
-### `Discover(int, int)`
+### `Discover(int, int, string)` {: #discover }
 : Discovers smart devices within the network of the host via UDP broadcast. Returns a list of [`TPLinkSmartDevice`](devices/device.md)'s.
   ``` csharp
-  public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000)
+  public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000, string target="255.255.255.255")
   ```
 
     __Parameters__
     : * `#!csharp int port`: Listen to broadcast responses on this port, defaults to `9999`
       * `#!csharp int timeout`: Timespan after which the discovery finishes, defaults to `5000`(5 seconds)
+      * `#!csharp string target`: ip address of discovery broadcast, defaults to `255.255.255.255`
 
 !!! tip "Method is awaitable" 
+
+!!! tip 
+    The discovery of devices within a network fails under certain circumstances. Some routers seem to block udp packets to the broadcast address (255.255.255.255), which is used to send out a discovery request.
+    In case of using different subnet's, what seems to resolve the issue is broadcasting to the subnet's local broadcast IP (such as 192.168.0.255, if IP is 192.168.0.X with a subnet mask of 255.255.255.0)
 
 ### `Associate(string, string, int)`
 : Makes smart device connect to specified network credentials

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -52,7 +52,7 @@ Smart devices which are already connected to the same network as the host device
     ``` csharp
     var discoveredDevices = await new TPLinkDiscovery().Discover();
     ```
-    <small> Full reference for [`TPLinkDiscovery.Discover()`](docs/discovery.md#discoverint-int)</small>
+    <small> Full reference for [`TPLinkDiscovery.Discover()`](docs/discovery.md#discover)</small>
 === "With event"
     ``` csharp
     TPLinkDiscovery discovery = new TPLinkDiscovery();

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,6 +23,7 @@ repo_url: https://www.github.com/CodeBardian/tplink-smartdevices-netstandard
 repo_name: CodeBardian/tplink-smartdevices-netstandard
 markdown_extensions:
   - admonition
+  - attr_list
   - def_list
   - pymdownx.tabbed
   - pymdownx.superfences

--- a/tplink-smartdevices/TPLinkDiscovery.cs
+++ b/tplink-smartdevices/TPLinkDiscovery.cs
@@ -30,14 +30,14 @@ namespace TPLinkSmartDevices
             DiscoveredDevices = new List<TPLinkSmartDevice>();
         }
 
-        public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000)
+        public async Task<List<TPLinkSmartDevice>> Discover(int port=9999, int timeout=5000, string target = "255.255.255.255")
         {
             discoveryComplete = false;
 
             DiscoveredDevices.Clear();
             PORT_NUMBER = port;
 
-            await SendDiscoveryRequestAsync();
+            await SendDiscoveryRequestAsync(target);
             
             udp = new UdpClient(PORT_NUMBER);
             IPEndPoint ip = new IPEndPoint(IPAddress.Any, PORT_NUMBER);
@@ -92,10 +92,10 @@ namespace TPLinkSmartDevices
                 Receive();
         }
 
-        private async Task SendDiscoveryRequestAsync()
+        private async Task SendDiscoveryRequestAsync(string target)
         {
             UdpClient client = new UdpClient(PORT_NUMBER);
-            IPEndPoint ip = new IPEndPoint(IPAddress.Broadcast, PORT_NUMBER);
+            IPEndPoint ip = new IPEndPoint(IPAddress.Parse(target), PORT_NUMBER);
 
             var discoveryJson = JObject.FromObject(new
             {


### PR DESCRIPTION
the discovery of devices within a network fails under certain circumstances. some routers seem to block udp packets to the broadcast address (255.255.255.255), which is used to send out for a discovery request. 

In case of using different subnets, what seems to resolve the issue is broadcasting to the subnet's local broadcast IP (such as 192.168.0.255 if IP is 192.168.0.x with a subnet mask of 255.255.255.0) instead of `IPAddress.Broadcast`

these changes will allow to specify a broadcast address as parameter of discovery